### PR TITLE
Error when computing `granularity` parameter list length in mlts_transform()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: maltese
 Type: Package
 Title: Machine Learning For Time Series
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(
     person("Mikhail", "Popov", email = "mikhail@wikimedia.org",
            role = c("aut", "cre"), comment = "@bearloga on Twitter"),
@@ -17,7 +17,6 @@ Suggests:
     knitr,
     rmarkdown,
     tidyverse,
-    timekit,
     dummy,
     mlr,
     nnet,
@@ -30,4 +29,4 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+mlts 0.1.3
+----------
+* Fixed typos in `mlts_transform()` function parameter definitions to bring them inline with function variable default values as this was confusing.
+* Fixed an error generated due to `names()` attribute not being the same length as the vector being passed when computing the granularity list length in `mlts_transform()` function.
+* Removed `timekit` dependency.
+
 mlts 0.1.1
 ----------
 

--- a/R/transform.R
+++ b/R/transform.R
@@ -9,8 +9,8 @@
 #'   time series as a numeric vector or factor; does not need to be a character
 #' @param p Number of previous observations to turn into features (think AR(p))
 #' @param xreg A character vector of column names of external regressors in \code{.data}
-#' @param granularity One of: seconds, minutes, hours, days, weeks, months,
-#'   quarters, years. If not specified, will attempt to detect.
+#' @param granularity One of: second, minute, hour, day, week, month,
+#'   quarter, year. If not specified, will attempt to detect.
 #' @param extras Whether maltese will create new features (like day of week)
 #' @param extrasAsFactors Whether to output extra features as factors or
 #'   numeric (default). If TRUE, some (like day of week or month) will be
@@ -49,7 +49,7 @@ mlts_transform <- function(.data, .dt, .y, p = 1, xreg = NULL, granularity = NUL
       message("Granularity detected as \"", granularity, "\".")
     }
     granularity <- as.numeric(factor(granularity, levels = c("second", "minute", "hour", "day", "week", "month", "year")))
-    extra_features <- as.list(numeric(granularity))
+    extra_features <- as.list(numeric(7 - (granularity - 1)))
     names(extra_features) <- c("second", "minute", "hour", "day", "week", "month", "year")[(granularity):7]
     if (extrasAsFactors) {
       extra_features[["year"]] <- data.frame(mlts_extras_year = ordered(lubridate::year(dt)))

--- a/man/mlts_transform.Rd
+++ b/man/mlts_transform.Rd
@@ -4,8 +4,9 @@
 \alias{mlts_transform}
 \title{Transform a time series to a machine learning-friendly format}
 \usage{
-mlts_transform(.data, .dt, .y, p = 1, xreg = NULL, granularity = NULL,
-  extras = FALSE, extrasAsFactors = FALSE, start = c("Mon", "Sun"))
+mlts_transform(.data, .dt, .y, p = 1, xreg = NULL,
+  granularity = NULL, extras = FALSE, extrasAsFactors = FALSE,
+  start = c("Mon", "Sun"))
 }
 \arguments{
 \item{.data}{A tidy data.frame/tbl}
@@ -20,8 +21,8 @@ time series as a numeric vector or factor; does not need to be a character}
 
 \item{xreg}{A character vector of column names of external regressors in \code{.data}}
 
-\item{granularity}{One of: seconds, minutes, hours, days, weeks, months,
-quarters, years. If not specified, will attempt to detect.}
+\item{granularity}{One of: second, minute, hour, day, week, month,
+quarter, year. If not specified, will attempt to detect.}
 
 \item{extras}{Whether maltese will create new features (like day of week)}
 


### PR DESCRIPTION
Hello,

I came upon your package while having a look at timetk package and I decided to give it a go as I work with time series data all the time. When I tried transforming the minutely data I kept getting the following error 
```
Error in names(extra_features) <- c("second", "minute", "hour", "day",  : 
  'names' attribute [6] must be the same length as the vector [1]
```
This is due to the calculation when figuring out the length of the `extra_features` list variable. Currently, it is set to the factor order from `granularity` variable. Since all the examples available are using `day` granularity, this is not causing any issues because `day` is right in the middle of an odd numbered list. Here is a simple example that would generate the error.
```
library(maltese)
library(tidyverse)


dtest <- tibble(timestamp = seq(from = as.POSIXct("2018-08-20 01 01:00:00"), 
                                by = "min", 
                                length.out = 15),
                count = runif(15))

d_mlts <- mlts_transform(dtest,
                         timestamp,
                         count,
                         granularity = "minute",
                         p = 7,
                         extras = T)
```
This can be fixed if `extra_features` variable is updated as 
```
extra_features <- as.list(numeric(7 - (granularity - 1)))
```
I also took the liberty of updating the package version and the news with the changes I have made.