### PR TITLE
Adding "h" argument to calculate future observations.

### DIFF
--- a/man/mlts_transform.Rd
+++ b/man/mlts_transform.Rd
@@ -4,7 +4,7 @@
 \alias{mlts_transform}
 \title{Transform a time series to a machine learning-friendly format}
 \usage{
-mlts_transform(.data, .dt, .y, p = 1, xreg = NULL,
+mlts_transform(.data, .dt, .y, p = 1, h = 0, xreg = NULL,
   granularity = NULL, extras = FALSE, extrasAsFactors = FALSE,
   start = c("Mon", "Sun"))
 }
@@ -18,6 +18,8 @@ does not need to be a character}
 time series as a numeric vector or factor; does not need to be a character}
 
 \item{p}{Number of previous observations to turn into features (think AR(p))}
+
+\item{h}{Number of future observations to turn in columns (useful for multi-target models)}
 
 \item{xreg}{A character vector of column names of external regressors in \code{.data}}
 
@@ -38,6 +40,7 @@ A \code{data.frame} suitable for supervised learners with columns:
     \item{dt}{The date or date-time (same as \code{dt})}
     \item{y}{The time series}
     \item{mlts_lag_k}{The previous k-th observation}
+    \item{mlts_lead_k}{The future k-th observation}
     \item{mlts_extras_?}{Extra features like hour of day, day of the week, month of the year, etc.}
   }
 }
@@ -48,5 +51,5 @@ Performs the necessary transformations to make a univariate
 }
 \examples{
 data("r_enwiki", package = "maltese")
-mlts <- mlts_transform(head(r_enwiki), date, pageviews)
+mlts <- mlts_transform(head(r_enwiki), date, pageviews, h = 1)
 }

--- a/tests/testthat/test-leads.R
+++ b/tests/testthat/test-leads.R
@@ -1,0 +1,15 @@
+context("leads-creation")
+
+x <- data.frame(
+  dt = as.POSIXct(c("2016-11-01", "2016-12-01", "2017-01-01", "2017-02-01", "2017-03-01"), tz = "UTC"),
+  y = 1:10
+)
+
+ml_x <- mlts_transform(x, dt, y, h = 10)
+
+test_that("leads are calculated correctly", {
+  expect_equal(ifelse(ml_x$y + 1 > 10, NA, ml_x$y + 1), ml_x$mlts_lead_1)
+  expect_equal(ifelse(ml_x$y + 2 > 10, NA, ml_x$y + 2), ml_x$mlts_lead_2)
+  expect_equal(ifelse(ml_x$y + 3 > 10, NA, ml_x$y + 3), ml_x$mlts_lead_3)
+  expect_equal(ifelse(ml_x$y + 10 > 10, NA_real_, ml_x$y + 10), ml_x$mlts_lead_10)
+})


### PR DESCRIPTION
@bearloga here is an initial patch addressing #4.

2 points I am still in doubt:

* __Naming__: I think it would be more intuitive to call the new variables as y_1, y_2, y_3 instead of mlts_lead_1. It also helps when using dplyr-like functionality like `select(dt, starts_with("mlts"))` for features and `select(dt, starts_with("y"))` for response variables.
* __Dealing with missing values__ Like lagging, we loose 1 observation for each leading variable added. We already filter out the missing observations for lagged variables. Should we do the same for when leading?

